### PR TITLE
Use docker-compose binary from official image 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1.10.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3.6.2
+        with:
+          images: ${{ github.actor }}/dcind
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2.7.0
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,22 @@
+# syntax=docker/dockerfile:1
 # Inspired by https://github.com/mumoshu/dcind
-FROM alpine:3.10
+ARG DOCKER_VERSION=20.10.9
+ARG DOCKER_COMPOSE_VERSION=1.29.2
+ARG ALPINE_BASE=alpine:3.15
+
+FROM docker/compose:alpine-${DOCKER_COMPOSE_VERSION} as docker-compose-image
+
+FROM ${ALPINE_BASE}
 LABEL maintainer="Dmitry Matrosov <amidos@amidos.me>"
-
-ENV DOCKER_VERSION=18.09.8 \
-    DOCKER_COMPOSE_VERSION=1.24.1
-
-# Install Docker and Docker Compose
-RUN apk --no-cache add bash curl util-linux device-mapper py-pip python-dev libffi-dev openssl-dev gcc libc-dev make iptables && \
-    curl https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz | tar zx && \
-    mv /docker/* /bin/ && \
-    chmod +x /bin/docker* && \
-    pip install docker-compose==${DOCKER_COMPOSE_VERSION} && \
-    rm -rf /root/.cache
+# use shared DOCKER_VERSION
+ARG DOCKER_VERSION
+# Copy  and Docker Compose from official image
+COPY --from=docker-compose-image /usr/local/bin/docker-compose /usr/local/bin/docker-compose
+# Install Docker
+RUN true \
+    && apk --no-cache add bash curl util-linux device-mapper iptables \
+    && curl -#RL https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz | tar zx \
+    && mv /docker/* /bin/
 
 # Include functions to start/stop docker daemon
 COPY docker-lib.sh /docker-lib.sh


### PR DESCRIPTION
Changes
---------

1. Dynamic version on build using ARG, default values:
    - alpine: 3.15
    - docker: 20.10.9
    - docker-compose: 1.24.1
2. Use docker-compose binary from official image via multistage build
3. Add Github Action to publish docker image
